### PR TITLE
Django 1.10 and 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ matrix:
           env: DJANGO_VERSION=">=1.6,<1.7"
         - python: "3.5"
           env: DJANGO_VERSION=">=1.7,<1.8"
-        # Django 1.9 and Python 3.3 don't work together.
+        # Django 1.9+ and Python 3.3 don't work together.
         - python: "3.3"
           env: DJANGO_VERSION=">=1.9,<1.10"
+        - python: "3.3"
+          env: DJANGO_VERSION=">=1.10,<1.11"
 
 install:
   - pip install "Django${DJANGO_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DJANGO_VERSION=">=1.8,<1.9"
   - DJANGO_VERSION=">=1.9,<1.10"
   - DJANGO_VERSION=">=1.10,<1.11"
+  - DJANGO_VERSION=">=1.11,<2.0"
 matrix:
     exclude:
         # Python 3.5 does not work with some django versions.
@@ -22,6 +23,8 @@ matrix:
           env: DJANGO_VERSION=">=1.9,<1.10"
         - python: "3.3"
           env: DJANGO_VERSION=">=1.10,<1.11"
+        - python: "3.3"
+          env: DJANGO_VERSION=">=1.11,<2.0"
 
 install:
   - pip install "Django${DJANGO_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DJANGO_VERSION=">=1.7,<1.8"
   - DJANGO_VERSION=">=1.8,<1.9"
   - DJANGO_VERSION=">=1.9,<1.10"
+  - DJANGO_VERSION=">=1.10,<1.11"
 matrix:
     exclude:
         # Python 3.5 does not work with some django versions.

--- a/djangoplugins/management/commands/syncplugins.py
+++ b/djangoplugins/management/commands/syncplugins.py
@@ -4,10 +4,7 @@ from optparse import make_option
 
 from django import VERSION as django_version
 
-try:
-    from django.core.management.base import BaseCommand
-except ImportError:
-    from django.core.management.base import NoArgsCommand as BaseCommand
+from django.core.management.base import BaseCommand
 from django.utils import six
 
 from djangoplugins.point import PluginMount
@@ -18,6 +15,14 @@ from djangoplugins.models import Plugin, PluginPoint, REMOVED, ENABLED
 class Command(BaseCommand):
     help = ("Syncs the registered plugins and plugin points with the model "
             "versions.")
+    if django_version <= (1, 8):
+        option_list = BaseCommand.option_list + (
+            make_option('--delete',
+                        action='store_true',
+                        dest='delete',
+                        default=False,
+                        help='Delete poll instead of closing it'),
+        )
 
     requires_model_validation = True
 

--- a/djangoplugins/management/commands/syncplugins.py
+++ b/djangoplugins/management/commands/syncplugins.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
                         action='store_true',
                         dest='delete',
                         default=False,
-                        help='Delete poll instead of closing it'),
+                        help='delete the REMOVED Plugin and PluginPoint '
+                        'instances.'),
         )
 
     requires_model_validation = True

--- a/djangoplugins/management/commands/syncplugins.py
+++ b/djangoplugins/management/commands/syncplugins.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import
 from optparse import make_option
 
 from django import VERSION as django_version
-from django.core.management.base import NoArgsCommand
+
+try:
+    from django.core.management.base import BaseCommand
+except ImportError:
+    from django.core.management.base import NoArgsCommand as BaseCommand
 from django.utils import six
 
 from djangoplugins.point import PluginMount
@@ -11,18 +15,20 @@ from djangoplugins.utils import get_plugin_name, load_plugins, db_table_exists
 from djangoplugins.models import Plugin, PluginPoint, REMOVED, ENABLED
 
 
-class Command(NoArgsCommand):
-    option_list = NoArgsCommand.option_list + (
-        make_option('--delete', action='store_true', dest='delete',
-                    help='delete the REMOVED Plugin and PluginPoint '
-                    'instances. '),
-    )
+class Command(BaseCommand):
     help = ("Syncs the registered plugins and plugin points with the model "
             "versions.")
 
     requires_model_validation = True
 
-    def handle_noargs(self, **options):
+    def add_arguments(self, parser):
+        parser.add_argument('--delete',
+            action='store_true',
+            dest='delete',
+            help='delete the REMOVED Plugin and PluginPoint '
+            'instances. ')
+
+    def handle(self, *args, **options):
         sync = SyncPlugins(options.get('delete'), options.get('verbosity'))
         sync.all()
 

--- a/djangoplugins/utils.py
+++ b/djangoplugins/utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.db import connection
 from django.conf import settings
-from django.conf.urls import include, patterns
+from django.conf.urls import include, url
 
 from importlib import import_module
 
@@ -30,13 +30,13 @@ def include_plugins(point, pattern=r'{plugin}/', urls='urls'):
     for plugin in point.get_plugins():
         if hasattr(plugin, urls) and hasattr(plugin, 'name'):
             _urls = getattr(plugin, urls)
-            for url in _urls:
-                url.default_args['plugin'] = plugin.name
-            pluginurls.append((
+            for _url in _urls:
+                _url.default_args['plugin'] = plugin.name
+            pluginurls.append(url(
                 pattern.format(plugin=plugin.name),
                 include(_urls)
             ))
-    return include(patterns('', *pluginurls))
+    return include(pluginurls)
 
 
 def import_app(app_name):

--- a/example-project/mycmsproject/settings.py
+++ b/example-project/mycmsproject/settings.py
@@ -82,3 +82,20 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_URL = '/static/'
+
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": ["templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
+        },
+    }
+]

--- a/example-project/mycmsproject/urls.py
+++ b/example-project/mycmsproject/urls.py
@@ -14,17 +14,16 @@ Including another URLconf
 """
 from __future__ import absolute_import
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 from djangoplugins.utils import include_plugins
 from .plugins import ContentType
 from .views import index
 
-urlpatterns = patterns(
-    'mycmsproject.views',
+urlpatterns = [
     url(r'^$', index, name='index'),
     url(r'^content/', include_plugins(ContentType)),
     url(r'^content/', include_plugins(
         ContentType, '{plugin}/(?P<pk>\d+)/', 'instance_urls'
     )),
-)
+]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='django-plugins',
       packages=find_packages(exclude=['sample-project']),
       install_requires=[
           'django>=1.6',
-          'django-dirtyfields',
+          'django-dirtyfields<1.3',
       ],
       url='https://github.com/krischer/django-plugins',
       download_url='http://pypi.python.org/pypi/django-plugins',


### PR DESCRIPTION
Hi, I saw in #12 that someone had attempted to add 1.11 support so I took the branch, polished it up, and added it to the test matrix. I think this works, but I'm a little concerned about the changes in utils.py - could someone who knows more about Django's URLs take a look and check that it makes sense please?

Thank you to @nisimpson for the original work found here: https://github.com/nisimpson/django-plugins/tree/django-1.11